### PR TITLE
Allow splitting apps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ Features
 
 * Rename app labels easily for third party apps without having to modify the source code. e.g. rename ``auth`` app to ``Authorisation`` for the django admin app.
 
+* Split large apps into smaller groups of models.
+
 * Reorder models within an app. e.g. ``auth.User`` model before the ``auth.Group`` model.
 
 * Exclude any of the models from the app list. e.g. Exclude ``auth.Group`` from the app list. Please note this only excludes the model from the app list and it doesn't protect it from access via url.

--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.conf import settings
 from django.contrib import admin
 from django.core.urlresolvers import resolve
@@ -71,6 +73,7 @@ class ModelAdminReorder(object):
 
         app = self.find_app(app_config['app'])
         if app:
+            app = deepcopy(app)
             # Rename app
             if 'label' in app_config:
                 app['name'] = app_config['label']


### PR DESCRIPTION
Looking at the docs examples it seems possible to split an app simply
defining different groups with the same 'app'. This proves not true:
with the following configuration the admin will present only the last
group repeated twice.

    ADMIN_REORDER = [
        {'app': 'auth', 'label': 'Auth User', 'models': ('auth.User',)},
        {'app': 'auth', 'label': 'Auth Group', 'models': ('auth.Group',)},
    ]

This happens because apps are modified inplace: just making sure that
process_app() creates a new copy makes possible creating groups with the
same app and possibly different contents.