### PR TITLE
Allow custom admin site

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from importlib import import_module
 
 from django.conf import settings
 from django.contrib import admin
@@ -12,6 +13,14 @@ class ModelAdminReorder(object):
         self.request = request
         self.app_list = app_list
 
+        admin_site_name = getattr(settings, 'ADMIN_REORDER_SITE', None)
+        if admin_site_name:
+            module_name, site_name = admin_site_name.rsplit('.', 1)
+            module = import_module(module_name)
+            self.admin_site = getattr(module, site_name)
+        else:
+            self.admin_site = admin.site
+
         self.config = getattr(settings, 'ADMIN_REORDER', None)
         if not self.config:
             # ADMIN_REORDER settings is not defined.
@@ -22,7 +31,7 @@ class ModelAdminReorder(object):
                 'ADMIN_REORDER config parameter must be tuple or list. '
                 'Got {config}'.format(config=self.config))
 
-        admin_index = admin.site.index(request)
+        admin_index = self.admin_site.index(request)
         try:
             # try to get all installed models
             app_list = admin_index.context_data['app_list']


### PR DESCRIPTION
Sometimes we do insane things with the admin, which require custom admin site. This PR includes a simple fix that enables developer to specify which admin site should be used instead of the default `django.contrib.admin.site`.

Usage:

in `settings.py`:

```
ADMIN_REORDER_SITE = 'myapp.custom_admin.site'
```

That's it. Of course, if setting is missing, the default site will be used.

---

Idea for the future: enable reorder to work on multiple sites.
