### PR TITLE
Fixed bug in HTTP path lookup

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import resolve
+from django.core.urlresolvers import resolve, Resolver404
 
 
 class ModelAdminReorder(object):
@@ -122,7 +122,10 @@ class ModelAdminReorder(object):
             return model
 
     def process_template_response(self, request, response):
-        url = resolve(request.path)
+        try:
+            url = resolve(request.path_info)
+        except Resolver404:
+            return response
         if not url.app_name == 'admin' and \
                 url.url_name not in ['index', 'app_list']:
             # current view is not a django admin index


### PR DESCRIPTION
Hi there,
I found a bug the middleware classes. I discovered it while I was deploying my application in a non-root environment. I this case the method call `django.core.urlresolvers.resolve(request.path)` throws an exception, because `request.path` is not the variable you are looking for. The correct lookup is `request.path_info`. In a common scenarion where the appication is deployed at the root of webserver the are the same.

Example:

Apache config: WSGIScriptAlias / /usr/local/share/myapp/wsgi.py
Request URL: www.mysite.org/admin
-> request.path = '/admin'
-> request.path_info = /admin'


Apache config: WSGIScriptAlias /testing /usr/local/share/myapp/wsgi.py
Request URL: www.mysite.org/testing/admin
-> request.path = '/testing/admin'
-> request.path_info = /admin'

