### PR TITLE
Fix middleware to support django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
 matrix:
     exclude:
         # Django 1.5 support Python 2.6.5 Python 2.7, Python 3.2 and 3.3.
-        # Django 1.6 requires Python (2.6.X, 2.7.X, 3.2.X, and 3.3.X)
-        # Django 1.7 requires Python 2.7, 3.2, 3.3, or 3.4
+        # Django 1.6 requires Python 2.6, 2.7, 3.2, or 3.3.
+        # Django 1.7 requires Python 2.7, 3.2, 3.3, or 3.4.
         # Django 1.8 requires Python 2.7, 3.2, 3.3, 3.4 or 3.5.
         # Django 1.9 requires Python 2.7, 3.4 or 3.5.
         # Django 1.10 requires Python 2.7, 3.4 or 3.5.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,16 @@ env:
     - DJANGO="Django==1.7"
     - DJANGO="Django==1.8"
     - DJANGO="Django==1.9"
+    - DJANGO="Django==1.10"
 
 matrix:
     exclude:
         # Django 1.5 support Python 2.6.5 Python 2.7, Python 3.2 and 3.3.
         # Django 1.6 requires Python (2.6.X, 2.7.X, 3.2.X, and 3.3.X)
         # Django 1.7 requires Python 2.7, 3.2, 3.3, or 3.4
-        # Django 1.8 requiert Python 2.7, 3.2, 3.3, 3.4 or 3.5.
-        # Django 1.9 requiert Python 2.7, 3.4 or 3.5.
+        # Django 1.8 requires Python 2.7, 3.2, 3.3, 3.4 or 3.5.
+        # Django 1.9 requires Python 2.7, 3.4 or 3.5.
+        # Django 1.10 requires Python 2.7, 3.4 or 3.5.
         # Python 2.6 support has been dropped for Django 1.7 onwards
         - python: "3.4"
           env: DJANGO="Django==1.5"
@@ -42,6 +44,10 @@ matrix:
           env: DJANGO="Django==1.9"
         - python: "3.3"
           env: DJANGO="Django==1.9"
+        - python: "2.6"
+          env: DJANGO="Django==1.10"
+        - python: "3.3"
+          env: DJANGO="Django==1.10"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,10 @@ matrix:
         - python: "3.3"
           env: DJANGO="Django==1.10"
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+# command to install dependencies, e.g. pip install -r requirements.txt
 install:
- - pip install $DJANGO --use-mirrors
- - pip install -r requirements-test.txt --use-mirrors
+ - pip install $DJANGO
+ - pip install -r requirements-test.txt
 
 # command to run tests using coverage, e.g. python setup.py test
 script: coverage run --source admin_reorder runtests.py

--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -5,8 +5,15 @@ from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import resolve
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
 
-class ModelAdminReorder(object):
+
+class ModelAdminReorder(MiddlewareMixin):
 
     def init_config(self, request, app_list):
         self.request = request


### PR DESCRIPTION
Hi,

Since django 1.10, the middleware has changed (https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware).
This pull request fix that in using the new class django.utils.deprecation.MiddlewareMixin.

Credits goes to:
https://github.com/zestedesavoir/django-cors-middleware/pull/25

Regards,

-- 
Mathis 'hasB4K' FELARDOS