### PR TITLE
BUG FIX. Suppose in ADMIN_REORDER settings we have and app comprising…

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -92,6 +92,8 @@ class ModelAdminReorder(MiddlewareMixin):
                 models = self.process_models(models_config)
                 if models:
                     app['models'] = models
+                else:
+                    return None
             return app
 
     def process_models(self, models_config):


### PR DESCRIPTION
… several different models: some of these models are accessible to a particular user, but some are not accessible. If we group together these unaccessible models in ADMIN_REORDER (under a new label), there is no necessity for the user to see these models in the admin panel. At the moment the user see the label and some unrelated models we have not listed in ADMIN_REORDER when this situation occurs. This change fixes this.