### PR TITLE
Raise NameError if model specified in ADMIN_REORDER can't be found

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -110,6 +110,10 @@ class ModelAdminReorder(MiddlewareMixin):
 
             if model:
                 ordered_models_list.append(model)
+            else:
+                raise NameError('"models" config for ADMIN_REORDER list '
+                                'item specified unknown model "%s"' %
+                                repr(model_config))
 
         return ordered_models_list
 


### PR DESCRIPTION
Makes it easier to catch configuration mistakes that otherwise just tend to get overseen.