### PR TITLE
Don't display empty apps

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -90,8 +90,9 @@ class ModelAdminReorder(MiddlewareMixin):
             if 'models' in app_config:
                 models_config = app_config.get('models')
                 models = self.process_models(models_config)
-                if models:
-                    app['models'] = models
+                if not models:
+                    return None
+                app['models'] = models
             return app
 
     def process_models(self, models_config):


### PR DESCRIPTION
An app may seem empty because the user doesn't have permission to see
any model. In the current implementation the app gets populated with all
the models originally defined in it. With the patch the app is not
displayed.