### PR TITLE
Allow specifying instances in admin

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -1,3 +1,4 @@
+import six
 from copy import deepcopy
 
 from django.apps import apps
@@ -5,6 +6,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import resolve, Resolver404, reverse
+from django.utils.module_loading import import_string
 
 try:
     from django.utils.deprecation import MiddlewareMixin
@@ -24,6 +26,14 @@ class ModelAdminReorder(MiddlewareMixin):
         if not self.config:
             # ADMIN_REORDER settings is not defined.
             raise ImproperlyConfigured('ADMIN_REORDER config is not defined.')
+
+        if isinstance(self.config, six.string_types):
+            try:
+                f = import_string(self.config)
+            except ImportError as e:
+                raise ImproperlyConfigured(
+                    "ADMIN_REORDER function not found: %s" % e)
+            self.config = f(request)
 
         if not isinstance(self.config, (tuple, list)):
             raise ImproperlyConfigured(


### PR DESCRIPTION
Hello,

this is a work in progress I'm using in a website of mine that allows specifying specific instances to be included in the django admin together with models.

As a specific use case, in my admin I'm displaying the normal `Folder` model from https://github.com/divio/django-filer, and a specific folder containing certain documents that must be accessible from first level. Such configuration is obtained by:

```python
ADMIN_REORDER = [
    # ...
    dict(app='totus', label='Documents',
        models=(
            dict(model='filer.Folder', label="All files and folders"),
            dict(instance='filer.Folder',
                lookup={"name": "Regulation documents"},
                urlpattern='admin:filer-directory_listing'),
        )),
    # ...
]
```

`urlpattern` is optional: the default is the change page of the model specified. If the model is not found no entry is added (consistently with models not found)

The feature can easily lead to requests like "can I add all my objects instances where the owner is the owner of the list, the `public` property is true etc... So I've changed the configuration: `ADMIN_REORDER` can now take a function name instead of a list of entries: the function is called with the request as input to get a list of entries. This allows performing queries before visualizing the admin page in order to look for objects matching certain properties.