### PR TITLE
Support Django 2.0

### DIFF
--- a/admin_reorder/middleware.py
+++ b/admin_reorder/middleware.py
@@ -3,7 +3,12 @@ from copy import deepcopy
 from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import resolve, Resolver404
+
+try:
+    from django.urls import resolve, Resolver404
+except ModuleNotFoundError:
+    # Deprecated since Django 1.10, removed in Django 2.0
+    from django.urls.urlresolvers import resolve, Resolver404
 
 try:
     from django.utils.deprecation import MiddlewareMixin


### PR DESCRIPTION
The urlresolvers module was [deprecated in Django 1.10 and removed in 2.0](https://docs.djangoproject.com/en/1.11/ref/urlresolvers/) 
